### PR TITLE
🐞 fix: Post 생성 예외 버그 수정

### DIFF
--- a/src/main/java/umc/blog/controller/PostController.java
+++ b/src/main/java/umc/blog/controller/PostController.java
@@ -24,8 +24,12 @@ public class PostController {
 
     // 글 생성
     @PostMapping
-    ResponseEntity<Post> createPost(@RequestBody PostDto postDto) {
-        return ResponseEntity.ok(postService.write(postDto));
+    ResponseEntity<?> createPost(@RequestBody PostDto postDto) {
+        try {
+            return ResponseEntity.ok(postService.write(postDto));
+        } catch (InputValidateException e) {
+            return errorMessage(e.getMessage());
+        }
     }
 
     // 글 수정

--- a/src/main/java/umc/blog/service/PostService.java
+++ b/src/main/java/umc/blog/service/PostService.java
@@ -22,6 +22,8 @@ public class PostService {
     // 글 생성
     @Transactional
     public Post write(PostDto postDto) {
+        validatePostDtoInput(postDto);
+
         Post newPost = Post.builder().
                 writer("익명"). // 원래 FK이기 때문에 숫자를 정의하는 게 좋지만 익명임을 나타내기 위해 이렇게 설정
                         title(postDto.getTitle()).
@@ -36,7 +38,7 @@ public class PostService {
     // 글 수정
     @Transactional
     public Post edit(Long id, PostEditDto editDto) {
-        validateInput(editDto);
+        validatePostEditDtoInput(editDto);
 
         Post targetPost = postRepository.findById(id).orElseThrow(
                 () -> new TargetNotFoundException("target not found")
@@ -55,8 +57,13 @@ public class PostService {
         postRepository.deleteById(id);
     }
 
-    public void validateInput(PostEditDto editDto) {
+    public void validatePostEditDtoInput(PostEditDto editDto) {
         if (editDto.getTitle() == null || editDto.getContent() == null)
+            throw new InputValidateException("validation error");
+    }
+
+    public void validatePostDtoInput(PostDto postDto) {
+        if (postDto.getTitle() == null || postDto.getContent() == null)
             throw new InputValidateException("validation error");
     }
 }


### PR DESCRIPTION
## 작업 주제
* 글 생성 예외 버그 수정
## 작업 내용
* 글을 생성할 때, 필수 값들을 넣지 않았을 때의 입력값을 검사하지 못했었습니다. 해당 예외를 추가하였습니다.
* 기존에 글 수정 시에만 사용되었던 `validateInput` 메서드 이름을 `validatePostEditDtoInput`으로 하였습니다. 글 생성 시 입력값을 검사하는 예외인 `validatePostDtoInput`으로 함께 만들어두기 위함입니다.
## 관련 이슈
* #1 